### PR TITLE
improve documentation, rename FolderRead to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,18 @@
 
 Useful functions in Go for Hashicorp Vault.
 
-Currently under active devlopment.
+Please read the [godoc documentation](https://godoc.org/github.com/Lingrino/vaku/vaku) for all usage
+information and examples.
 
-[Documentation](https://godoc.org/github.com/Lingrino/vaku/vaku)
+Critical path and folder functions are finished. This project is currently under active devlopment and
+exported functions are still subject to change.
 
-Terminology:
-- A `path` in vault references a location. This location can either be a secret itself or a folder containing secrets. A clean path does not start or end with a `/`
-- A `key` is the same as a path *except* that it can end in a `/`, signifying for certain that it is a folder
-- A `folder` is a `key` that ends in a `/`. Folders are not secrets, but they contain secrets and/or other folders
-- In this repo all functions prefixed with `Path` act once on the path specified. `PathDelete()` calls delete on that path and stops. On the other hand, all function starting with `Folder` call their `Path` equivalent on all keys within, recursively. `PathDelete()` deletes a single `path` and `FolderDelete()` deletes an entire `folder`.
-
-Planned Functions:
+**Planned Functions:**
 - [x] Path List
 - [x] Path Read
 - [x] Path Write
 - [x] Path Delete
+- [ ] Path Destroy (v2 mounts only)
 - [x] Path Copy
 - [x] Path Move
 - [x] Path Update
@@ -29,9 +26,21 @@ Planned Functions:
 - [x] Folder Read
 - [x] Folder Write
 - [x] Folder Delete
+- [ ] Folder Destroy (v2 mounts only)
 - [x] Folder Copy
 - [x] Folder Move
 - [ ] Folder Search
 - [ ] Folder Diff
+- [ ] Folder Map
 - [ ] Policy Enforce
 - [ ] Approle Enforce
+- [ ] Userpass Enforce
+- [ ] Add to Vault CLI
+
+**Running Tests:**
+
+Tests are meant to be run side by side with a real Vault server docker image. This
+creates an external dependency for the tests but makes it much simpler to test different
+Vault versions and key/value mounts. With docker and docker-compose installed tests
+can be run with a simple `make test`. CircleCI will also build all commits and report
+status on all PRs.

--- a/vaku/client.go
+++ b/vaku/client.go
@@ -4,12 +4,24 @@ import (
 	vapi "github.com/hashicorp/vault/api"
 )
 
-// Client is a wrapper around a real Vault API client.
+// Client is a simple wrapper around a real Vault API client. All Vaku
+// functions are defined on Client as well, which lets anyone already
+// using a Vault Client easily make use of Vaku.
 type Client struct {
 	*vapi.Client
 }
 
-// NewClient Returns a new empty Client type
+// NewClient returns a new empty Vaku Client. Using this function requires
+// that you initialize and set the nested Vault client on your own before
+// Vaku functions will work.
 func NewClient() *Client {
 	return &Client{}
+}
+
+// NewClientFromVaultClient takes in an official Vault Client that you have
+// already created and returns a Vaku client that wraps your Vault client.
+func NewClientFromVaultClient(vc *vapi.Client) *Client {
+	vakuClient := NewClient()
+	vakuClient.Client = vc
+	return vakuClient
 }

--- a/vaku/defaults.go
+++ b/vaku/defaults.go
@@ -1,4 +1,7 @@
 package vaku
 
-// MaxConcurrency is the max number of threads to launch when calling vault. Default is 10
+// MaxConcurrency is the maximum number of threads/workers to use when calling Folder-based
+// functions that execute concurrently. The default value is 10, but a stable and well-tuned
+// Vault server should be able to handle up to 100 without issues. Use with caution and tune
+// specifically to your environment and storage backend.
 var MaxConcurrency = 10

--- a/vaku/defaults_test.go
+++ b/vaku/defaults_test.go
@@ -1,4 +1,4 @@
 package vaku_test
 
-const VaultAddr = "http://0.0.0.0:8300"
-const VaultToken = "hunter2"
+const vaultAddr = "http://0.0.0.0:8300"
+const vaultToken = "hunter2"

--- a/vaku/doc.go
+++ b/vaku/doc.go
@@ -1,0 +1,51 @@
+/*
+Package vaku wraps an official Vault client with useful high-level functions.
+
+Terminology
+
+A 'path' in vault references a location. This location can either be a secret itself
+or a folder containing secrets. A clean path does not start or end with a '/'.
+
+A 'key' is the same as a path except that it can end in a '/', signifying for certain
+that it is a folder. A trailing slash is a way of notifying that a path is a folder,
+but lack of a trailing slash does not imply the opposite.
+
+A 'folder' is a key that ends in a '/'. Folders are not secrets, but they contain
+secrets and/or other folders.
+
+Summary
+
+Vaku is intended to provide useful functions for Vault that let users operate securely and efficiently. Using
+the official Vault API and CLI it is only possible to take CRUD actions on individual paths, however normal
+usage of vault will eventually lead to a desire for more advanced function like the ability to copy or move
+paths or even entire folders. The functions in this package can be broken into the distinct categroies below.
+
+Helpers
+
+These exported functions provide useful ways to manage Vault paths in code. They provide utilities
+for cleaning, combining, and splitting Vault paths, keys, and folders. Many of these utilities exist
+unexported in the official Vault Golang API, but they are useful enough to provide to end users here.
+
+Path Functions
+
+Path functions act on vault paths under both versions of the key/value secrets engine. They should not be
+used on paths outside of those engines. The path functions in Vaku are opinionated and easy to use. However
+this means that they do not support many of the features in the Vault API. For example, PathRead() does not
+return any metadata or other information about a secret, only the data of the secret itself.
+
+Folder Functions
+
+Folder functions act on vault folders under both versions of the key/value secrets engine. They should
+not be used on folders outside of those engines. In general, a folder function acts on all paths found
+by listing the input path recursively. For example, FolderDelete() on "secret/test" will list all paths
+within "secret/test" and its subfolders and then call PathDelete() on each one. Folder functions are
+executed concurrently using a worker pool of goroutines and channels.
+
+Policy and Role Functions
+
+Policy and role functions are intended to provide an opinionated and easy way of enforcing configuration
+in code. When setup properly you can run these functions daily (or as often as you like) to ensure that all
+policies and roles in Vault are defined in code. These functions will create all resources as defined in
+code and then delete any resources not defined.
+*/
+package vaku

--- a/vaku/folder_copy.go
+++ b/vaku/folder_copy.go
@@ -10,9 +10,10 @@ type folderCopyWorkerInput struct {
 	resultsC chan<- error
 }
 
-// FolderCopy takes in a source PathInput and target PathInput and copies
-// every key in the source to the target. Note that this will overwrite
-// any existing keys at the target paths.
+// FolderCopy takes in a source PathInput and target PathInput and copies every path in
+// the source to the target. Note that this will copy the input path if it is a secret and
+// all paths under the input path that result from calling FolderList() on that path. Also
+// note that this will overwrite any existing keys at the target paths.
 func (c *Client) FolderCopy(s *PathInput, t *PathInput) error {
 	var err error
 

--- a/vaku/folder_delete.go
+++ b/vaku/folder_delete.go
@@ -10,7 +10,9 @@ type folderDeleteWorkerInput struct {
 	resultsC chan<- error
 }
 
-// FolderDelete takes in a path and deletes every key in that folder and all sub-folders
+// FolderDelete takes in a path and deletes every key in that folder and all sub-folders.
+// Note that this calls PathDelete() on every path found in the folder, and for v2 secret
+// mounts that means deleting the active version, but not all versions.
 func (c *Client) FolderDelete(i *PathInput) error {
 	var err error
 

--- a/vaku/folder_list.go
+++ b/vaku/folder_list.go
@@ -22,8 +22,9 @@ type folderListWorkerInput struct {
 	resultsWG *sync.WaitGroup
 }
 
-// FolderList takes in a PathInput and recursively walks PathList,
-// listing all paths nested in the folder
+// FolderList takes in a PathInput and walks the path by calling PathList
+// on the input path and all folders within that path as well. Returns the
+// results as a sorted slice of paths.
 func (c *Client) FolderList(i *PathInput) ([]string, error) {
 	var err error
 	var output []string

--- a/vaku/folder_move.go
+++ b/vaku/folder_move.go
@@ -10,9 +10,8 @@ type folderMoveWorkerInput struct {
 	resultsC chan<- error
 }
 
-// FolderMove takes in a source PathInput and target PathInput and moves
-// every key in the source to the target. Note that this will overwrite
-// any existing keys at the target paths.
+// FolderMove calls FolderCopy() with the same inputs followed by FolderDelete()
+// on the source path if the copy was successful.
 func (c *Client) FolderMove(s *PathInput, t *PathInput) error {
 	var err error
 

--- a/vaku/folder_read_test.go
+++ b/vaku/folder_read_test.go
@@ -14,7 +14,7 @@ type TestFolderReadData struct {
 	outputErr bool
 }
 
-func TestFolderRead(t *testing.T) {
+func TestFolderReadOnce(t *testing.T) {
 	t.Parallel()
 	c := clientInitForTests(t)
 
@@ -106,7 +106,7 @@ func TestFolderRead(t *testing.T) {
 	}
 
 	for _, d := range tests {
-		o, e := c.FolderRead(d.input)
+		o, e := c.FolderReadOnce(d.input)
 		assert.Equal(t, d.output, o)
 		if d.outputErr {
 			assert.Error(t, e)
@@ -116,7 +116,7 @@ func TestFolderRead(t *testing.T) {
 	}
 }
 
-func TestFolderReadAll(t *testing.T) {
+func TestFolderRead(t *testing.T) {
 	c := clientInitForTests(t)
 
 	tests := map[int]TestFolderReadData{
@@ -233,7 +233,7 @@ func TestFolderReadAll(t *testing.T) {
 	}
 
 	for _, d := range tests {
-		o, e := c.FolderReadAll(d.input)
+		o, e := c.FolderRead(d.input)
 		assert.Equal(t, d.output, o)
 		if d.outputErr {
 			assert.Error(t, e)

--- a/vaku/folder_write.go
+++ b/vaku/folder_write.go
@@ -15,9 +15,11 @@ type writeInput struct {
 	data map[string]interface{}
 }
 
-// FolderWrite takes in a map of paths to data that should be written to that path.
-// Note that mount/version information is determined only once using a random path in the map
-// and cached for all future writes. Therefore this function cannot write to two mounts of
+// FolderWrite takes in a map of paths to data that should be written to that path. Users may
+// find this function difficult to call on its own because the input can be large and specific,
+// however the output of FolderRead matches the input of FolderWrite(), making them easy to use
+// together. Note that mount/version information is determined only once using a random path in
+// the map and cached for all future writes. Therefore this function cannot write to two mounts of
 // different versions in the same call.
 func (c *Client) FolderWrite(d map[string]map[string]interface{}) error {
 	var err error

--- a/vaku/helpers.go
+++ b/vaku/helpers.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// KeyIsFolder returns true if the string ends in a '/'
+// KeyIsFolder returns true if the string ends in a '/'.
 func (c *Client) KeyIsFolder(k string) bool {
 	if strings.HasSuffix(k, "/") {
 		return true
@@ -13,8 +13,8 @@ func (c *Client) KeyIsFolder(k string) bool {
 	return false
 }
 
-// KeyJoin takes n strings and combines them into a clean vault key
-// vault keys have a trailing '/' if they are a folder
+// KeyJoin takes n strings and combines them into a clean Vault key. Vault keys
+// (as opposed to paths) optionally have a trailing '/' to signify they are a folder.
 func (c *Client) KeyJoin(ks ...string) string {
 	if strings.HasSuffix(ks[len(ks)-1], "/") {
 		return strings.TrimPrefix(path.Join(ks...)+"/", "/")
@@ -22,26 +22,26 @@ func (c *Client) KeyJoin(ks ...string) string {
 	return strings.TrimPrefix(path.Join(ks...), "/")
 }
 
-// PathJoin takes n strings and combines them into a clean vault path
-// Paths in vault never begin or end in a slash
+// PathJoin takes n strings and combines them into a clean Vault path. Paths in
+// vault (unlike keys) never end with a '/'.
 func (c *Client) PathJoin(ps ...string) string {
 	return strings.TrimSuffix(c.KeyJoin(ps...), "/")
 }
 
-// KeyClean just calls KeyJoin with one string
-// KeyJoin already cleans keys, this exists only for naming simplicity
+// KeyClean simply calls KeyJoin() with one string. KeyJoin already cleans keys, so
+// this helper exists only for naming simplicity.
 func (c *Client) KeyClean(k string) string {
 	return c.KeyJoin(k)
 }
 
-// PathClean just calls PathJoin with one string
-// PathJoin already cleans paths, this exists only for naming simplicity
+// PathClean just calls PathJoin() with one string. PathJoin already cleans paths, so
+// this helper exists only for naming simplicity.
 func (c *Client) PathClean(p string) string {
 	return strings.TrimSuffix(c.KeyClean(p), "/")
 }
 
-// KeyBase returns the last element of k and cleans it
-// If empty or all slashes, return an empty string
+// KeyBase returns the last element of path k and cleans it. If k is empty or all slashes,
+// return an empty string
 func (c *Client) KeyBase(k string) string {
 	addSlash := strings.HasSuffix(k, "/")
 
@@ -55,28 +55,29 @@ func (c *Client) KeyBase(k string) string {
 	return base
 }
 
-// PathBase returns the last element of p and cleans it
-// If empty or all slashes, return an empty string
+// PathBase calls KeyBase(p) and also trims the trailing '/' if necessary
 func (c *Client) PathBase(p string) string {
 	return strings.TrimSuffix(c.KeyBase(p), "/")
 }
 
-// SliceAddKeyPrefix adds a prefix to every key in a slice
+// SliceAddKeyPrefix takes in a slice of keys (strings) and a prefix and adds
+// that prefix to every key in the slice
 func (c *Client) SliceAddKeyPrefix(ss []string, p string) {
 	for i, s := range ss {
 		ss[i] = c.KeyJoin(p, s)
 	}
 }
 
-// SliceTrimKeyPrefix trims a prefix from every key in a slice
+// SliceTrimKeyPrefix takes in a slice of keys (strings) and a prefix and trims
+// that prefix from every key in the slice
 func (c *Client) SliceTrimKeyPrefix(ss []string, p string) {
 	for i, s := range ss {
 		ss[i] = c.KeyJoin(strings.TrimPrefix(s, p))
 	}
 }
 
-// SliceRemoveFolders takes a list of keys and removes any
-// folders (strings that end in a '/') and returns the filtered list
+// SliceRemoveFolders takes a list of keys and removes any folders (strings that end in a '/')
+// and returns the new filtered list
 func (c *Client) SliceRemoveFolders(ss []string) []string {
 	var output []string
 	for _, s := range ss {

--- a/vaku/main.go
+++ b/vaku/main.go
@@ -1,2 +1,0 @@
-// Package vaku provides useful functions in Go for Hashicorp Vault
-package vaku

--- a/vaku/main_test.go
+++ b/vaku/main_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-var SeededOnce = false
+var seededOnce = false
 
+// Initialize a new simple vault client to be used for tets
 func clientInitForTests(t *testing.T) *vaku.Client {
 	// Initialize a new vault client
 	vclient, err := vapi.NewClient(vapi.DefaultConfig())
@@ -23,16 +24,16 @@ func clientInitForTests(t *testing.T) *vaku.Client {
 	client.Client = vclient
 
 	// Set the address and token to the test values
-	client.SetToken(VaultToken)
-	client.SetAddress(VaultAddr)
+	client.SetToken(vaultToken)
+	client.SetAddress(vaultAddr)
 
 	// Seed the client if it has never been seeded
-	if !SeededOnce {
+	if !seededOnce {
 		err = seed(t, client)
 		if err != nil {
 			t.Fatal(errors.Wrapf(err, "Failed to seed the vault client"))
 		}
-		SeededOnce = true
+		seededOnce = true
 	}
 	return client
 }

--- a/vaku/mount_helpers.go
+++ b/vaku/mount_helpers.go
@@ -7,19 +7,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MountInfoOutput holds output for MountInfo
-// FullPath is the original input path
-// mountPath is the path of the mount
-// MountlessPath is the FullPath with the mountPath removed
-// mountVersion is the version of the mount, or "unknown"
+// MountInfoOutput holds output for MountInfo. This data can be useful for
+// determining which key/value engine version a path is mounted on and acting
+// accordingly.
 type MountInfoOutput struct {
-	FullPath      string
-	MountPath     string
-	MountlessPath string
-	MountVersion  string
+	FullPath      string // The original input path
+	MountPath     string // The path of the mount
+	MountlessPath string // The FullPath with the MountPath removed
+	MountVersion  string // The version of the mount, default "unknown"
 }
 
-// MountInfo gets information for the mount of the specified path
+// MountInfo gets information about the mount at the specified path that can be
+// used to determine what actions to take on that path.
 func (c *Client) MountInfo(p string) (*MountInfoOutput, error) {
 	var err error
 	var output MountInfoOutput

--- a/vaku/path_copy.go
+++ b/vaku/path_copy.go
@@ -4,10 +4,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathCopy takes in a source PathInput and a target PathInput.
-// It then copies the data from one path to another. PathCopy can
-// copy from one mount to another by default. Note that this will
-// overwrite an existing key at the target path.
+// PathCopy takes in a source PathInput and a target PathInput. It then copies the data
+// from one path to another. Note that PathCopy can copy can be used to copy data from one
+// mount to another. Note also that this will overwrite any existing key at the target path.
 func (c *Client) PathCopy(s *PathInput, t *PathInput) error {
 	var err error
 

--- a/vaku/path_delete.go
+++ b/vaku/path_delete.go
@@ -4,9 +4,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathDelete takes in a path and deletes it. For v2
-// mounts this function only "marks the path as deleted",
-// it does nothing with the versions of the path
+// PathDelete takes in a PathInput and calls the native Vault delete on it. For v2
+// mounts this function only "marks the path as deleted", it does nothing with the
+// versions of the path
 func (c *Client) PathDelete(i *PathInput) error {
 	var err error
 

--- a/vaku/path_list.go
+++ b/vaku/path_list.go
@@ -7,8 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathList takes in a PathInput, calls vault list, extracts
-// the secret, and returns a slice of strings
+// PathList takes in a PathInput, calls the native vault list on it, extracts
+// the secret (list of keys), and returns it. Note that any metadata or other
+// information returned by the list is thrown away.
 func (c *Client) PathList(i *PathInput) ([]string, error) {
 	var err error
 	var output []string

--- a/vaku/path_move.go
+++ b/vaku/path_move.go
@@ -4,10 +4,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathMove takes in a source PathInput and a target PathInput.
-// It then moves (destructively) the data from one path to another.
-// PathMove can move from one mount to another by default. Note that
-// this will overwrite any existing key at the target path.
+// PathMove calls PathCopy() with the same inputs followed by PathDelete() on
+// the source if the copy was successful. Note that this will overwrite any existing
+// keys at the target Path.
 func (c *Client) PathMove(s *PathInput, t *PathInput) error {
 	var err error
 

--- a/vaku/path_read.go
+++ b/vaku/path_read.go
@@ -6,8 +6,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathRead takes in a path, calls vault read, extracts
-// the secret, and returns it as a map of strings to values
+// PathRead takes in a PathInput, calls the native vault read on it, extracts the secret,
+// and returns it as a map of strings to values. Note that this is the way secrets
+// are represented in Vault, as map[string]interface{} (JSON)
 func (c *Client) PathRead(i *PathInput) (map[string]interface{}, error) {
 	var err error
 	var output map[string]interface{}

--- a/vaku/path_types.go
+++ b/vaku/path_types.go
@@ -7,7 +7,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathInput is the input for List
+// PathInput is the standard way of representing a Vault path with Vaku. The only
+// required input is the Path itself. You can also specify TrimPathPrefix which
+// determines if returned paths include the full input Path or only the nested paths.
+// This struct also holds unexported data about the version of the key/value mount
+// that the path is in.
 type PathInput struct {
 	Path           string
 	TrimPathPrefix bool
@@ -18,8 +22,9 @@ type PathInput struct {
 	mountVersion   string
 }
 
-// NewPathInput takes in a Path and returns
-// the default PathInput. Only Path is required
+// NewPathInput takes in a Path and returns the default PathInput. This function can be
+// used to easily take a path string and use it as input for a Vaku function. TrimPathPrefix
+// is true by default, which produces behavior similar to the Vault API.
 func NewPathInput(p string) *PathInput {
 	return &PathInput{
 		Path:           p,
@@ -32,8 +37,10 @@ func NewPathInput(p string) *PathInput {
 	}
 }
 
-// InitPathInput fills in missing values from PathInput
-// with defaults and mount information
+// InitPathInput fills in missing values from PathInput with defaults and mount information. This
+// function will rarely be useful by end-users, but could lead to performance gain if multiple actions
+// are being taken on the same PathInput by preventing repeats of the relatively expensive task of
+// determining mount information about the path
 func (c *Client) InitPathInput(i *PathInput) error {
 	var err error
 

--- a/vaku/path_update.go
+++ b/vaku/path_update.go
@@ -4,9 +4,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathUpdate takes in a path and new data to write. If then dates the data
-// at the existing path with the new data, merging the two with precedence given
-// to the new data.
+// PathUpdate takes in a path with existing data and new data to write to that path.
+// It then merges the data at the existing path with the new data, with precedence given
+// to the new data, and writes the merged data back to Vault
 func (c *Client) PathUpdate(i *PathInput, d map[string]interface{}) error {
 	var err error
 

--- a/vaku/path_write.go
+++ b/vaku/path_write.go
@@ -4,8 +4,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PathWrite takes in a path and data to write, and writes that
-// data to the specified path
+// PathWrite takes in a PathInput and data to written to that path. It then
+// calls the native vault write with that data at the specified path.
 func (c *Client) PathWrite(i *PathInput, d map[string]interface{}) error {
 	var err error
 


### PR DESCRIPTION
Adds more consistent and verbose documentation to the package and each exported field.

Also renames `FolderRead` to `FolderReadOnce` and `FolderReadAll` to `FolderRead` to be consistent with the functionality of all other Folder functions.