### PR TITLE
Cli improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.10.3
-      - image: vault:0.10.4
+      - image: circleci/golang:1.11.1
+      - image: vault:0.11.3
         environment:
           SKIP_SETCAP: true
           VAULT_DEV_ROOT_TOKEN_ID: hunter2
@@ -29,7 +29,7 @@ jobs:
           command: go test -cover -v ./...
   deploy:
     docker:
-      - image: circleci/golang:1.10.3
+      - image: circleci/golang:1.11.1
     working_directory: /go/src/github.com/Lingrino/vaku
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Vaku](www/assets/logo-vaku-sm.png?raw=true)](www/assets/logo-vaku-sm.png "Vaku")
-
 # vaku
+
+[![Vaku](www/assets/logo-vaku-sm.png?raw=true)](www/assets/logo-vaku-sm.png "Vaku")
 
 [![CircleCI](https://circleci.com/gh/Lingrino/vaku.svg?style=svg)](https://circleci.com/gh/Lingrino/vaku)
 
@@ -18,11 +18,12 @@ Vaku is now V1. The API and CLI will be backwards compatible until the next poin
 See the checklist below for progress and upcoming features.
 
 **API Functionality:**
+
 - [x] Path List
 - [x] Path Read
 - [x] Path Write
 - [x] Path Delete
-- [ ] Path Destroy (v2 mounts only)
+- [x] Path Destroy (v2 mounts only)
 - [x] Path Copy
 - [x] Path Move
 - [x] Path Update
@@ -32,25 +33,21 @@ See the checklist below for progress and upcoming features.
 - [x] Folder Read
 - [x] Folder Write
 - [x] Folder Delete
-- [ ] Folder Destroy (v2 mounts only)
+- [x] Folder Destroy (v2 mounts only)
 - [x] Folder Copy
 - [x] Folder Move
 - [x] Folder Search
 - [ ] Folder Diff
 - [ ] Folder Map
-- [ ] Policy Enforce
-- [ ] Approle Enforce
-- [ ] Userpass Enforce
 - [ ] Add Timeouts to Workers
-- [ ] Support Wrapped Secrets
 
 **CLI Improvements:**
+
 - [ ] Add tests
 - [ ] Add to homebrew
 - [ ] Add example usage
 - [ ] Support concurrency flag
 - [ ] Support more than JSON output
-- [ ] Add write/update commands (native CLI probably better for writing data)
 
 **Running Tests:**
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Vaku](www/assets/logo-vaku-sm.png?raw=true)](www/assets/logo-vaku-sm.png "Vaku")
 
 [![CircleCI](https://circleci.com/gh/Lingrino/vaku.svg?style=svg)](https://circleci.com/gh/Lingrino/vaku)
-
 [![Go Report Card](https://goreportcard.com/badge/github.com/Lingrino/vaku)](https://goreportcard.com/report/github.com/Lingrino/vaku)
+[![GoDoc](https://godoc.org/github.com/Lingrino/vaku/vaku?status.svg)](https://godoc.org/github.com/Lingrino/vaku/vaku)
 
 A CLI and Go API that add useful functions on top of Hashicorp Vault.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the checklist below for progress and upcoming features.
 
 **CLI Improvements:**
 
+- [ ] Add docs
 - [ ] Add tests
 - [ ] Add to homebrew
 - [ ] Add example usage

--- a/README.md
+++ b/README.md
@@ -17,28 +17,28 @@ regarding the Vaku CLI
 Vaku is now V1. The API and CLI will be backwards compatible until the next point release.
 See the checklist below for progress and upcoming features.
 
-**API Functionality:**
+**API/CLI Functionality:**
 
 - [x] Path List
 - [x] Path Read
-- [x] Path Write
+- [x] Path Write (API only)
 - [x] Path Delete
 - [x] Path Destroy (v2 mounts only)
 - [x] Path Copy
 - [x] Path Move
-- [x] Path Update
+- [x] Path Update (API only)
 - [x] Path Search
 - [ ] Path Diff
 - [x] Folder List
 - [x] Folder Read
-- [x] Folder Write
+- [x] Folder Write (API only)
 - [x] Folder Delete
 - [x] Folder Destroy (v2 mounts only)
 - [x] Folder Copy
 - [x] Folder Move
 - [x] Folder Search
 - [ ] Folder Diff
-- [ ] Folder Map
+- [x] Folder Map (CLI Only)
 - [ ] Add Timeouts to Workers
 
 **CLI Improvements:**
@@ -47,7 +47,6 @@ See the checklist below for progress and upcoming features.
 - [ ] Add to homebrew
 - [ ] Add example usage
 - [ ] Support concurrency flag
-- [ ] Support more than JSON output
 
 **Running Tests:**
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -7,3 +7,6 @@ var noTrimPathPrefix bool
 // indentString is used in folder_map to determine which string to
 // use as an indent for the sub-sections
 var indentString string
+
+// format is the format of our string output. Defaults to json
+var format string

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -3,3 +3,7 @@ package cmd
 // noTrimPathPrefix determines if the output paths should
 // have the input path trimmed from the prefix
 var noTrimPathPrefix bool
+
+// indentString is used in folder_map to determine which string to
+// use as an indent for the sub-sections
+var indentString string

--- a/cmd/folder_list.go
+++ b/cmd/folder_list.go
@@ -33,5 +33,5 @@ var folderListCmd = &cobra.Command{
 
 func init() {
 	folderCmd.AddCommand(folderListCmd)
-	folderListCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", true, "Output full paths instead of paths with the input path trimmed")
+	folderListCmd.Flags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/folder_map.go
+++ b/cmd/folder_map.go
@@ -25,7 +25,7 @@ var folderMapCmd = &cobra.Command{
 			fmt.Printf("%s", errors.Wrapf(err, "Failed to list folder %s", args[0]))
 			os.Exit(1)
 		} else {
-			var output string
+			var output []string
 			var prevPS []string
 			var written bool
 
@@ -44,7 +44,7 @@ var folderMapCmd = &cobra.Command{
 					if len(ps) != psi+1 {
 						word = word + "/"
 					}
-					output = output + strings.Repeat(indentString, psi) + word + "\n"
+					output = append(output, strings.Repeat(indentString, psi)+word)
 					written = true
 				}
 				prevPS = ps

--- a/cmd/folder_map.go
+++ b/cmd/folder_map.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Lingrino/vaku/vaku"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var folderMapCmd = &cobra.Command{
+	Use:   "map [path]",
+	Short: "Return a text map of the folder, with subfolders indented by depth",
+
+	Args: cobra.ExactArgs(1),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		input := vaku.NewPathInput(args[0])
+		input.TrimPathPrefix = true
+
+		list, err := vgc.FolderList(input)
+		if err != nil {
+			fmt.Printf("%s", errors.Wrapf(err, "Failed to list folder %s", args[0]))
+			os.Exit(1)
+		} else {
+			var output string
+			var prevPS []string
+			var written bool
+
+			// Loop over each return path
+			for _, path := range list {
+				// Split the path and loop over each piece of the path
+				ps := strings.Split(path, "/")
+				for psi, word := range ps {
+					// Don't write anything if we've already written the "parent" word
+					// Once we write one part of a path, we should write all of it
+					if len(prevPS) > psi && word == prevPS[psi] && !written {
+						continue
+					}
+
+					// Unless this is the last word, add a "/" to the output
+					if len(ps) != psi+1 {
+						word = word + "/"
+					}
+					output = output + strings.Repeat(indentString, psi) + word + "\n"
+					written = true
+				}
+				prevPS = ps
+				written = false
+			}
+
+			fmt.Println(output)
+		}
+	},
+}
+
+func init() {
+	folderCmd.AddCommand(folderMapCmd)
+	folderMapCmd.Flags().StringVarP(&indentString, "indent-string", "I", "    ", "The string to use for indenting the map")
+}

--- a/cmd/folder_map.go
+++ b/cmd/folder_map.go
@@ -50,8 +50,9 @@ var folderMapCmd = &cobra.Command{
 				prevPS = ps
 				written = false
 			}
-
-			fmt.Println(output)
+			print(map[string]interface{}{
+				args[0]: output,
+			})
 		}
 	},
 }

--- a/cmd/folder_read.go
+++ b/cmd/folder_read.go
@@ -31,5 +31,5 @@ var folderReadCmd = &cobra.Command{
 
 func init() {
 	folderCmd.AddCommand(folderReadCmd)
-	folderReadCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
+	folderReadCmd.Flags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/folder_read.go
+++ b/cmd/folder_read.go
@@ -31,5 +31,5 @@ var folderReadCmd = &cobra.Command{
 
 func init() {
 	folderCmd.AddCommand(folderReadCmd)
-	folderReadCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", true, "Output full paths instead of paths with the input path trimmed")
+	folderReadCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/folder_search.go
+++ b/cmd/folder_search.go
@@ -31,5 +31,5 @@ var folderSearchCmd = &cobra.Command{
 
 func init() {
 	folderCmd.AddCommand(folderSearchCmd)
-	folderSearchCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
+	folderSearchCmd.Flags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/folder_search.go
+++ b/cmd/folder_search.go
@@ -31,5 +31,5 @@ var folderSearchCmd = &cobra.Command{
 
 func init() {
 	folderCmd.AddCommand(folderSearchCmd)
-	folderSearchCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", true, "Output full paths instead of paths with the input path trimmed")
+	folderSearchCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/folder_update.go
+++ b/cmd/folder_update.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var folderUpdateCmd = &cobra.Command{
+	Hidden:                true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+
+	Use:   "write",
+	Short: "Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API",
+	Long:  "Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API",
+
+	Args:             cobra.ArbitraryArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ERROR: Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API")
+	},
+}
+
+func init() {
+	folderCmd.AddCommand(folderUpdateCmd)
+}

--- a/cmd/folder_write.go
+++ b/cmd/folder_write.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var folderWriteCmd = &cobra.Command{
+	Hidden:                true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+
+	Use:   "write",
+	Short: "Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API",
+	Long:  "Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API",
+
+	Args:             cobra.ArbitraryArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ERROR: Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API")
+	},
+}
+
+func init() {
+	folderCmd.AddCommand(folderWriteCmd)
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 
 	"github.com/Lingrino/vaku/vaku"
-	"github.com/pkg/errors"
-
 	vapi "github.com/hashicorp/vault/api"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 )
 
 // vgc is the vaku client used by CLI commands
@@ -51,10 +50,41 @@ func authVGC() {
 }
 
 func print(i map[string]interface{}) {
-	json, err := json.MarshalIndent(i, "", "    ")
-	if err != nil {
-		log.Fatal(err)
-	}
+	if format == "json" {
+		json, err := json.MarshalIndent(i, "", "    ")
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	fmt.Println(string(json))
+		fmt.Println(string(json))
+	} else if format == "text" {
+		for _, v := range i {
+			textPrint(v)
+		}
+	} else {
+		fmt.Printf("ERROR: %s is not a valid or supported output format", format)
+	}
+}
+
+func textPrint(i interface{}) {
+	switch t := i.(type) {
+	case map[string]map[string]interface{}:
+		for k, v := range t {
+			fmt.Printf("\n%+v\n", k)
+			fmt.Println(strings.Repeat("-", len(k)))
+			textPrint(v)
+		}
+	case map[string]interface{}:
+		for k, v := range t {
+			fmt.Printf("%s => %+v\n", k, v)
+		}
+	case []string:
+		for _, v := range t {
+			fmt.Println(v)
+		}
+	case string:
+		fmt.Println(t)
+	default:
+		fmt.Printf("%+v\n", t)
+	}
 }

--- a/cmd/path_list.go
+++ b/cmd/path_list.go
@@ -31,5 +31,5 @@ var pathListCmd = &cobra.Command{
 
 func init() {
 	pathCmd.AddCommand(pathListCmd)
-	pathListCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
+	pathListCmd.Flags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/path_list.go
+++ b/cmd/path_list.go
@@ -31,5 +31,5 @@ var pathListCmd = &cobra.Command{
 
 func init() {
 	pathCmd.AddCommand(pathListCmd)
-	pathListCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", true, "Output full paths instead of paths with the input path trimmed")
+	pathListCmd.PersistentFlags().BoolVarP(&noTrimPathPrefix, "no-trim-path-prefix", "T", false, "Output full paths instead of paths with the input path trimmed")
 }

--- a/cmd/path_update.go
+++ b/cmd/path_update.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var pathUpdateCmd = &cobra.Command{
+	Hidden:                true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+
+	Use:   "write",
+	Short: "Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API",
+	Long:  "Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API",
+
+	Args:             cobra.ArbitraryArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ERROR: Vaku CLI does not support updates/writes. Please use either the native Vault CLI or the Vaku API")
+	},
+}
+
+func init() {
+	pathCmd.AddCommand(pathUpdateCmd)
+}

--- a/cmd/path_write.go
+++ b/cmd/path_write.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var pathWriteCmd = &cobra.Command{
+	Hidden:                true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+
+	Use:   "write",
+	Short: "Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API",
+	Long:  "Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API",
+
+	Args:             cobra.ArbitraryArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ERROR: Vaku CLI does not support writes. Please use either the native Vault CLI or the Vaku API")
+	},
+}
+
+func init() {
+	pathCmd.AddCommand(pathWriteCmd)
+}

--- a/cmd/vaku.go
+++ b/cmd/vaku.go
@@ -28,7 +28,7 @@ API documentation is available at https://godoc.org/github.com/Lingrino/vaku/vak
 }
 
 func init() {
-	vakuCmd.PersistentFlags().StringVarP(&format, "format", "o", "json", "The output format to use. One of: \"json\", \"text\"")
+	vakuCmd.PersistentFlags().StringVarP(&format, "format", "o", "text", "The output format to use. One of: \"json\", \"text\"")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/vaku.go
+++ b/cmd/vaku.go
@@ -28,7 +28,7 @@ API documentation is available at https://godoc.org/github.com/Lingrino/vaku/vak
 }
 
 func init() {
-	vakuCmd.PersistentFlags().StringVarP(&format, "format", "o", "text", "The output format to use. One of: \"json\", \"text\"")
+	vakuCmd.PersistentFlags().StringVarP(&format, "format", "o", "json", "The output format to use. One of: \"json\", \"text\"")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/vaku.go
+++ b/cmd/vaku.go
@@ -27,11 +27,19 @@ CLI documentation is available using 'vaku help [cmd]'
 API documentation is available at https://godoc.org/github.com/Lingrino/vaku/vaku`,
 }
 
+func init() {
+	vakuCmd.PersistentFlags().StringVarP(&format, "format", "o", "json", "The output format to use. One of: \"json\", \"text\"")
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the vakuCmd.
 func Execute(v string) {
+	var err error
+
 	version = v
-	if err := vakuCmd.Execute(); err != nil {
+
+	err = vakuCmd.Execute()
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/vaku/folder_delete_test.go
+++ b/vaku/folder_delete_test.go
@@ -33,11 +33,17 @@ func TestFolderDelete(t *testing.T) {
 
 	for _, d := range tests {
 		e := c.FolderDelete(d.input)
-		_, re := c.FolderRead(d.input)
+		r, re := c.FolderRead(d.input)
 		if d.outputErr {
 			assert.Error(t, e)
 		} else {
-			assert.Error(t, re)
+			if re == nil {
+				for _, data := range r {
+					assert.Equal(t, "SECRET_HAS_BEEN_DELETED", data["VAKU_STATUS"])
+				}
+			} else {
+				assert.Error(t, re)
+			}
 			assert.NoError(t, e)
 		}
 	}

--- a/vaku/folder_move_test.go
+++ b/vaku/folder_move_test.go
@@ -53,13 +53,19 @@ func TestFolderMove(t *testing.T) {
 		c.FolderDelete(d.inputTarget)
 		bsr, _ := c.FolderRead(d.inputSource)
 		e := c.FolderMove(d.inputSource, d.inputTarget)
-		_, sre := c.FolderRead(d.inputSource)
+		sr, sre := c.FolderRead(d.inputSource)
 		tr, _ := c.FolderRead(d.inputTarget)
 		if d.outputErr {
 			assert.Error(t, e)
 		} else {
+			if sre == nil {
+				for _, data := range sr {
+					assert.Equal(t, "SECRET_HAS_BEEN_DELETED", data["VAKU_STATUS"])
+				}
+			} else {
+				assert.Error(t, sre)
+			}
 			assert.Equal(t, bsr, tr)
-			assert.Error(t, sre)
 			assert.NoError(t, e)
 		}
 		seed(t, c) // reseed every time for this test

--- a/vaku/main_test.go
+++ b/vaku/main_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 
 	"github.com/Lingrino/vaku/vaku"
+	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
-
-	vapi "github.com/hashicorp/vault/api"
 )
 
 var seededOnce = false
@@ -14,7 +13,7 @@ var seededOnce = false
 // Initialize a new simple vault client to be used for tets
 func clientInitForTests(t *testing.T) *vaku.Client {
 	// Initialize a new vault client
-	vclient, err := vapi.NewClient(vapi.DefaultConfig())
+	vclient, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "Failed to create a vault client for testing"))
 	}
@@ -45,7 +44,7 @@ func seed(t *testing.T, c *vaku.Client) error {
 	var err error
 
 	// Turn on logging to stdout
-	c.Sys().EnableAuditWithOptions("audit_stdout", &vapi.EnableAuditOptions{
+	c.Sys().EnableAuditWithOptions("audit_stdout", &api.EnableAuditOptions{
 		Type: "file",
 		Options: map[string]string{
 			"file_path": "stdout",
@@ -54,12 +53,12 @@ func seed(t *testing.T, c *vaku.Client) error {
 	})
 
 	// Mount the two secret backends
-	c.Sys().Mount("secretv1/", &vapi.MountInput{
+	c.Sys().Mount("secretv1/", &api.MountInput{
 		Type: "kv",
 		Options: map[string]string{
 			"version": "1"},
 	})
-	c.Sys().Mount("secretv2/", &vapi.MountInput{
+	c.Sys().Mount("secretv2/", &api.MountInput{
 		Type: "kv",
 		Options: map[string]string{
 			"version": "2",

--- a/vaku/path_delete_test.go
+++ b/vaku/path_delete_test.go
@@ -41,11 +41,15 @@ func TestPathDelete(t *testing.T) {
 
 	for _, d := range tests {
 		e := c.PathDelete(d.input)
-		_, re := c.PathRead(d.input)
+		r, re := c.PathRead(d.input)
 		if d.outputErr {
 			assert.Error(t, e)
 		} else {
-			assert.Error(t, re)
+			if re == nil {
+				assert.Equal(t, "SECRET_HAS_BEEN_DELETED", r["VAKU_STATUS"])
+			} else {
+				assert.Error(t, re)
+			}
 			assert.NoError(t, e)
 		}
 	}

--- a/vaku/path_move_test.go
+++ b/vaku/path_move_test.go
@@ -53,13 +53,17 @@ func TestPathMove(t *testing.T) {
 	for _, d := range tests {
 		bsr, _ := c.PathRead(d.inputSource)
 		e := c.PathMove(d.inputSource, d.inputTarget)
-		_, sre := c.PathRead(d.inputSource)
+		sr, sre := c.PathRead(d.inputSource)
 		tr, _ := c.PathRead(d.inputTarget)
 		if d.outputErr {
 			assert.Error(t, e)
 		} else {
+			if sre == nil {
+				assert.Equal(t, "SECRET_HAS_BEEN_DELETED", sr["VAKU_STATUS"])
+			} else {
+				assert.Error(t, sre)
+			}
 			assert.Equal(t, bsr, tr)
-			assert.Error(t, sre)
 			assert.NoError(t, e)
 		}
 	}

--- a/vaku/path_read.go
+++ b/vaku/path_read.go
@@ -32,6 +32,15 @@ func (c *Client) PathRead(i *PathInput) (map[string]interface{}, error) {
 	// V2 Mounts return a nested map[string]interface{} at secret.Data["data"]
 	output = secret.Data
 	if i.mountVersion == "2" && output != nil {
+		metadata := secret.Data["metadata"].(map[string]interface{})
+		if metadata["deletion_time"].(string) != "" {
+			// Note that path_search and folder_search depend on this VAKU_STATUS
+			outputS := map[string]interface{}{
+				"VAKU_STATUS": "SECRET_HAS_BEEN_DELETED",
+			}
+			return outputS, nil
+		}
+
 		data := secret.Data["data"]
 		if data != nil {
 			output = data.(map[string]interface{})

--- a/vaku/path_search.go
+++ b/vaku/path_search.go
@@ -10,7 +10,8 @@ import (
 // PathSearch takes in a PathInput and a search string, reads the path, and searches
 // the read data for a match on the search string. Returns true if the string is found
 // in the data. Note that this is a simple search that just checks if the secret
-// contains the search string anywhere.
+// contains the search string anywhere. Also note that if this is a KV version 2 mount
+// and the input path has been deleted (but not destroyed) this returns false with no error.
 func (c *Client) PathSearch(i *PathInput, s string) (bool, error) {
 	var err error
 
@@ -26,6 +27,9 @@ func (c *Client) PathSearch(i *PathInput, s string) (bool, error) {
 	// is not the fastest or "right" way to search but it's the least complex and works
 	// in this limited space.
 	for k, v := range read {
+		if strings.Contains(k, "VAKU_STATUS") {
+			return false, err
+		}
 		if strings.Contains(k, s) {
 			return true, err
 		}

--- a/www/index.html
+++ b/www/index.html
@@ -7,8 +7,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
         <!-- Bootstrap CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4"
-            crossorigin="anonymous">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+            integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
         <title>Vaku</title>
     </head>
@@ -28,10 +28,14 @@
                         </div>
                         <div class="row mb-5">
                             <p class="lead">
-                                Vaku is a CLI and Go API that extends the official Hashicorp Vault CLIs and APIs with useful high-level functions such as
-                                the ability to copy, move, and search vault paths and folders. The CLI and API are purpose-built
-                                to deal with the actual secret content of paths and folders, and they therefore do not make
-                                use of or reveal Vault features like metadata and wrapping. Use the tools as you see fit
+                                Vaku is a CLI and Go API that extends the official Hashicorp Vault CLIs and APIs with
+                                useful high-level functions such as
+                                the ability to copy, move, and search vault paths and folders. The CLI and API are
+                                purpose-built
+                                to deal with the actual secret content of paths and folders, and they therefore do not
+                                make
+                                use of or reveal Vault features like metadata and wrapping. Use the tools as you see
+                                fit
                                 and file issues for anything you think could be improved. Thanks!
                             </p>
                         </div>
@@ -61,14 +65,11 @@
         </div>
 
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-            crossorigin="anonymous">
-            </script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ"
-            crossorigin="anonymous">
-            </script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
-            crossorigin="anonymous">
-            </script>
+            crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+            crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+            crossorigin="anonymous"></script>
     </body>
 
 </html>


### PR DESCRIPTION
- Add `vaku folder map` command
- Add godoc badge in README
- Update vault, go, and dependency versions
- Update README todo
- Add text output in addition to json
- Fix `--no-trim-path-prefix` flag
- Add hidden CLI warnings for write/update commands
- Update `pathRead` to return `VAKU_STATUS` when a user attempts to read a deleted (but not destroyed) secret on a V2 mount. This fixes an issue where searching a folder with a secret like this would cause an error (we now skip deleted secrets in searches instead)
- Update bootstrap version