### PR TITLE
Update golangci-lint, add linters, fix lint errors, update packages

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31 # https://github.com/golangci/golangci-lint/releases
+          version: v1.32 # https://github.com/golangci/golangci-lint/releases
   gomod:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - errorlint
     - funlen
     - gochecknoglobals
     - gochecknoinits
@@ -34,12 +35,14 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
     - whitespace
+    - wrapcheck
   disable:
     - interfacer # deprecated
     - maligned # not worth savings
@@ -69,6 +72,7 @@ issues:
     - path: cmd/
       linters:
         - dupl # CLIs are a lot of similar-looking code!
+        - wrapcheck # errors don't need to be wrapped in thin CLIs
     - path: _test.go
       linters:
         - dupl # many functions in tests look like duplicates
@@ -76,6 +80,7 @@ issues:
         - gochecknoglobals # globals in tests are fine
         - gocognit # test functions can be long/complex
         - gomnd # there are many magic numbers in tests
+        - wrapcheck # errors don't need to be wrapped in tests
     - path: example_*_test.go
       linters:
         - errcheck # not required to check errors in examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.1 - 2020-10-31
+
+### Added
+
+- GEN: Update packages
+- GEN: Update golangci-lint
+- GEN: Enable `errorlint`, `tparallel`, `wrapcheck` linters
+- GEN: Fix found linter issues
+- API: `ErrApplyOptions` now returned in `api.NewClient`
+
 ## 2.1.0 - 2020-10-27
 
 ### Added

--- a/api/client.go
+++ b/api/client.go
@@ -12,6 +12,8 @@ import (
 var (
 	// ErrNumWorkers when workers is not a supported number.
 	ErrNumWorkers = errors.New("invalid workers")
+	// ErrApplyOptions when options fails to apply.
+	ErrApplyOptions = errors.New("applying options")
 )
 
 const (
@@ -163,7 +165,7 @@ func NewClient(opts ...Option) (*Client, error) {
 	for _, opt := range opts {
 		err := opt.apply(client)
 		if err != nil {
-			return nil, err
+			return nil, newWrapErr("", ErrApplyOptions, err)
 		}
 	}
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -75,7 +75,7 @@ func TestNewClient(t *testing.T) {
 			name:    "bad workers",
 			give:    []Option{WithWorkers(0)},
 			want:    nil,
-			wantErr: []error{ErrNumWorkers},
+			wantErr: []error{ErrApplyOptions, ErrNumWorkers},
 		},
 		{
 			name: "error",
@@ -83,7 +83,7 @@ func TestNewClient(t *testing.T) {
 				withError(errInject),
 			},
 			want:    nil,
-			wantErr: []error{errInject},
+			wantErr: []error{ErrApplyOptions, errInject},
 		},
 	}
 

--- a/api/error.go
+++ b/api/error.go
@@ -59,7 +59,7 @@ func newWrapErr(msg string, is, wraps error) *wrapErr {
 
 // Is compares an error to e.is.
 func (e *wrapErr) Is(target error) bool {
-	return target == e.is
+	return target == e.is //nolint:errorlint
 }
 
 // Error() returns the error message.

--- a/api/version.go
+++ b/api/version.go
@@ -2,5 +2,5 @@ package vaku
 
 // Version gives the current Vaku API version.
 func Version() string {
-	return "2.1.0"
+	return "2.1.1"
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestVersion(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "2.1.0", Version())
+	assert.Equal(t, "2.1.1", Version())
 }

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -46,7 +46,7 @@ func TestInitVakuClient(t *testing.T) {
 		{
 			name:        "bad workers",
 			giveWorkers: 0,
-			wantErr:     "initializing vaku client\nworkers must 1 or greater: 0: invalid workers",
+			wantErr:     "initializing vaku client\napplying options: workers must 1 or greater: 0: invalid workers",
 		},
 		{
 			name:        "fail vault.NewClient",

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -26,7 +26,7 @@ func (c *cli) combineErr(e1, e2 error) error {
 	if e1 == nil {
 		return e2
 	}
-	return fmt.Errorf("%s\n%s%s", e1, c.flagIndent, e2)
+	return fmt.Errorf("%s\n%s%s", e1, c.flagIndent, e2) //nolint:errorlint
 }
 
 // output handles outputting all of our messages (regular output or errors).

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -19,12 +19,12 @@ func TestVersion(t *testing.T) {
 		{
 			name:        "version test",
 			giveVersion: "test",
-			wantOut:     "API: 2.1.0\nCLI: test\n",
+			wantOut:     "API: 2.1.1\nCLI: test\n",
 		},
 		{
 			name:        "version version",
 			giveVersion: "version",
-			wantOut:     "API: 2.1.0\nCLI: version\n",
+			wantOut:     "API: 2.1.1\nCLI: version\n",
 		},
 		{
 			name:        "args",

--- a/go.mod
+++ b/go.mod
@@ -7,15 +7,16 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
 	github.com/hashicorp/vault v1.4.7
-	github.com/hashicorp/vault-plugin-secrets-kv v0.5.6
+	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault/api v1.0.5-0.20200317185738-82f498082f02
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200922221257-86ee24f8530b
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
-	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/spf13/cobra v1.1.0
+	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee // indirect
-	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
-	google.golang.org/api v0.33.0 // indirect
+	google.golang.org/api v0.34.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,8 @@ github.com/hashicorp/vault-plugin-secrets-gcpkms v0.5.5/go.mod h1:b6RwFD1bny1zbf
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.5/go.mod h1:oNyUoMMQq6uNTwyYPnkldiedaknYbPfQIdKoyKQdy2g=
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.6 h1:i8EoRnLD6+U1RSHaCFs3DGXsV4r7L9LHMtMivNmsK1I=
 github.com/hashicorp/vault-plugin-secrets-kv v0.5.6/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
+github.com/hashicorp/vault-plugin-secrets-kv v0.7.0 h1:Sq5CmKWxQu+MtO6AXYM+STPHGnrGD50iKuwzaw87OVM=
+github.com/hashicorp/vault-plugin-secrets-kv v0.7.0/go.mod h1:B/Cybh5aVF7LNAMHwVBxY8t7r2eL0C6HVGgTyP4nKK4=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2 h1:X9eK6NSb1qafvoEYxH5nomAW3JXl12KybR77NpgqpIU=
 github.com/hashicorp/vault-plugin-secrets-mongodbatlas v0.1.2/go.mod h1:YRW9zn9NZNitRlPYNAWRp/YEdKCF/X8aOg8IYSxFT5Y=
 github.com/hashicorp/vault-plugin-secrets-openldap v0.1.3-0.20200623230748-8c6a0913e025 h1:SV9Vhs0FF3o43wYBV+JYPyC6t2h4ZwKU/EgST3Nba4Q=
@@ -745,6 +747,8 @@ github.com/pierrec/lz4 v2.2.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
+github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -832,6 +836,8 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.1.0 h1:aq3wCKjTPmzcNWLVGnsFVN4rflK7Uzn10F8/aw8MhdQ=
 github.com/spf13/cobra v1.1.0/go.mod h1:yk5b0mALVusDL5fMM6Rd1wgnoO5jUPhwsQ6LQAJTidQ=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
+github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
@@ -917,6 +923,8 @@ golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee h1:4yd7jl+vXjalO5ztz6Vc1VADv+S/80LGJmyl1ROJ2AI=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1017,6 +1025,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2By
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 h1:Bx6FllMpG4NWDOfhMBz1VR2QYNp/SAOHPIAsaVmxfPo=
 golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1164,6 +1174,8 @@ google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSr
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
 google.golang.org/api v0.33.0 h1:+gL0XvACeMIvpwLZ5rQZzLn5cwOsgg8dIcfJ2SYfBVw=
 google.golang.org/api v0.33.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
+google.golang.org/api v0.34.0 h1:k40adF3uR+6x/+hO5Dh4ZFUqFp67vxvbpafFiJxl10A=
+google.golang.org/api v0.34.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
- GEN: Update packages
- GEN: Update golangci-lint
- GEN: Enable `errorlint`, `tparallel`, `wrapcheck` linters
- GEN: Fix found linter issues
- API: `ErrApplyOptions` now returned in `api.NewClient`