### PR TITLE
Add environment variable for bearer auth token

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	vault "github.com/hashicorp/vault/api"
@@ -96,6 +97,9 @@ type withVaultClient struct {
 func (o withVaultClient) apply(c *Client) error {
 	c.vc = o.client
 	c.vl = o.client.Logical()
+	if bearerToken := os.Getenv("BEARER_AUTH_TOKEN"); strings.TrimSpace(bearerToken) != "" {
+		o.client.AddHeader("Authorization", "Bearer "+bearerToken)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We are using vaku for folder list and copy. vaku is a very useful tool for the vault ecosystem. 
However, our internal network has edge gateway which requires valid bearer token. 

Everytime, we need to ssh into jump box to run the script with vaku. 

It would be great that if vaku supports adding auth bearer token environment into Vault request header.