### PR TITLE
Only upload coverage if secret is defined

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,7 @@ jobs:
         run: go test -cover -coverprofile=c.out -covermode=atomic -race -v ./...
       - name: Upload Codeclimate Coverage
         uses: paambaati/codeclimate-action@v2.7.5
+        if: ${{ env.CC_TEST_REPORTER_ID != '' }}
         with:
           prefix: github.com/lingrino/vaku/v2/
           coverageLocations: ${{ github.workspace }}/c.out:gocov


### PR DESCRIPTION
Secrets are not passed to dependabot PRs