### PR TITLE
Fix the full path where there are nested directories with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.0 - 2021-05-15
+
+Thank you to [@karakanb](https://github.com/karakanb) for finding and fixing a tricky bug!
+
+### Changed
+
+- API: Add `AddPrefix` and `AddPrefixList` helper functions.
+- GEN: Fixed a bug where `folder search` would hang if the mount path shared a name with a folder.
+
 ## 2.2.0 - 2021-02-16
 
 ### Changed

--- a/api/client.go
+++ b/api/client.go
@@ -180,6 +180,14 @@ func (c *Client) swapPaths(data map[string]map[string]interface{}, src, dst stri
 	EnsurePrefixMap(data, dst)
 }
 
+// inputPath returns a path ready for input into a read/write/list/delete.
+func (c *Client) inputPath(path, root string) string {
+	if c.absolutePath {
+		return path
+	}
+	return AddPrefix(path, root)
+}
+
 // outputPath returns a path for the user, given their formatting preferences.
 func (c *Client) outputPath(path, root string) string {
 	if c.absolutePath {
@@ -191,6 +199,6 @@ func (c *Client) outputPath(path, root string) string {
 // outputPaths prepares a list of paths for the user, given their formatting preferences.
 func (c *Client) outputPaths(paths []string, root string) {
 	if c.absolutePath {
-		EnsurePrefixList(paths, root)
+		AddPrefixList(paths, root)
 	}
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -239,6 +239,47 @@ func TestOutputPaths(t *testing.T) {
 	}
 }
 
+func TestInputPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		giveRoot string
+		givePath string
+
+		wantAbs   string
+		wantNoAbs string
+	}{
+		{
+			giveRoot:  "0/1/2",
+			givePath:  "3/4",
+			wantAbs:   "3/4",
+			wantNoAbs: "0/1/2/3/4",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.giveRoot, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := NewClient(WithAbsolutePath(true))
+			assert.NoError(t, err)
+
+			path := client.inputPath(tt.givePath, tt.giveRoot)
+			assert.Equal(t, tt.wantAbs, path)
+		})
+		t.Run(tt.giveRoot, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := NewClient()
+			assert.NoError(t, err)
+
+			path := client.inputPath(tt.givePath, tt.giveRoot)
+			assert.Equal(t, tt.wantNoAbs, path)
+		})
+	}
+}
+
 // withError returns the passed in error for Option error injection.
 func withError(e error) Option {
 	return withErrorOpt{e}

--- a/api/folder_delete.go
+++ b/api/folder_delete.go
@@ -70,7 +70,7 @@ func (c *Client) folderDeleteWork(i *folderDeleteWorkInput) error {
 			if !ok {
 				return nil
 			}
-			path = EnsurePrefix(path, i.root)
+			path = c.inputPath(path, i.root)
 			err := i.deleteF(path)
 			if err != nil {
 				return err

--- a/api/folder_destroy.go
+++ b/api/folder_destroy.go
@@ -61,7 +61,7 @@ func (c *Client) folderDestroyWork(i *folderDestroyWorkInput) error {
 			if !ok {
 				return nil
 			}
-			path = EnsurePrefix(path, i.root)
+			path = c.inputPath(path, i.root)
 			err := c.PathDestroy(path, i.versions)
 			if err != nil {
 				return newWrapErr(i.root, ErrFolderDestroy, err)

--- a/api/folder_list.go
+++ b/api/folder_list.go
@@ -132,8 +132,7 @@ func (c *Client) pathListWork(path string, i *folderListWorkInput) error {
 		for _, item := range list {
 			i.wg.Add(1)
 			go func(item string) {
-				item = AddPrefix(item, path)
-				i.pathC <- item
+				i.pathC <- c.inputPath(item, path)
 			}(item)
 		}
 	} else {

--- a/api/folder_list.go
+++ b/api/folder_list.go
@@ -132,7 +132,7 @@ func (c *Client) pathListWork(path string, i *folderListWorkInput) error {
 		for _, item := range list {
 			i.wg.Add(1)
 			go func(item string) {
-				item = EnsurePrefix(item, path)
+				item = AddPrefix(item, path)
 				i.pathC <- item
 			}(item)
 		}

--- a/api/folder_read.go
+++ b/api/folder_read.go
@@ -100,7 +100,7 @@ func (c *Client) folderReadWork(i *folderReadWorkInput) error {
 
 // pathReadWork reads the path adds results to the channel.
 func (c *Client) pathReadWork(path string, i *folderReadWorkInput) error {
-	path = EnsurePrefix(path, i.root)
+	path = AddPrefix(path, i.root)
 
 	read, err := c.PathRead(path)
 	if err != nil {

--- a/api/folder_read.go
+++ b/api/folder_read.go
@@ -98,9 +98,9 @@ func (c *Client) folderReadWork(i *folderReadWorkInput) error {
 	}
 }
 
-// pathReadWork reads the path adds results to the channel.
+// pathReadWork reads the path and adds results to the channel.
 func (c *Client) pathReadWork(path string, i *folderReadWorkInput) error {
-	path = AddPrefix(path, i.root)
+	path = c.inputPath(path, i.root)
 
 	read, err := c.PathRead(path)
 	if err != nil {

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -23,6 +23,11 @@ func EnsureFolder(p string) string {
 	return PathJoin(p, "/")
 }
 
+// AddPrefix adds a prefix to a path.
+func AddPrefix(p, pfx string) string {
+	return PathJoin(pfx, p)
+}
+
 // EnsurePrefix adds a prefix to a path if it doesn't already have it.
 func EnsurePrefix(p, pfx string) string {
 	if strings.HasPrefix(p, pfx) {
@@ -31,12 +36,14 @@ func EnsurePrefix(p, pfx string) string {
 	return PathJoin(pfx, p)
 }
 
-// AddPrefix adds a prefix to a path.
-func AddPrefix(p, pfx string) string {
-	return PathJoin(pfx, p)
+// AddPrefixList adds a prefix to every item in a list.
+func AddPrefixList(l []string, pfx string) {
+	for i, v := range l {
+		l[i] = PathJoin(pfx, v)
+	}
 }
 
-// EnsurePrefixList adds a prefix to every item in a list.
+// EnsurePrefixList adds a prefix to every item in a list if it doesn't already have it.
 func EnsurePrefixList(l []string, pfx string) {
 	for i, v := range l {
 		if !strings.HasPrefix(v, pfx) {

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -31,6 +31,11 @@ func EnsurePrefix(p, pfx string) string {
 	return PathJoin(pfx, p)
 }
 
+// AddPrefix adds a prefix to a path.
+func AddPrefix(p, pfx string) string {
+	return PathJoin(pfx, p)
+}
+
 // EnsurePrefixList adds a prefix to every item in a list.
 func EnsurePrefixList(l []string, pfx string) {
 	for i, v := range l {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -139,6 +139,61 @@ func TestEnsureFolder(t *testing.T) {
 	}
 }
 
+func TestAddPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		give       string
+		givePrefix string
+		want       string
+	}{
+		{
+			give:       "",
+			givePrefix: "",
+			want:       "",
+		},
+		{
+			give:       "a",
+			givePrefix: "",
+			want:       "a",
+		},
+		{
+			give:       "",
+			givePrefix: "a",
+			want:       "a",
+		},
+		{
+			give:       "a/",
+			givePrefix: "a",
+			want:       "a/a/",
+		},
+		{
+			give:       "a",
+			givePrefix: "a/",
+			want:       "a/a",
+		},
+		{
+			give:       "a/b/c/d",
+			givePrefix: "a/b/",
+			want:       "a/b/a/b/c/d",
+		},
+		{
+			give:       "a/b/c/d",
+			givePrefix: "b",
+			want:       "b/a/b/c/d",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.give, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, AddPrefix(tt.give, tt.givePrefix))
+		})
+	}
+}
+
 func TestEnsurePrefix(t *testing.T) {
 	t.Parallel()
 
@@ -190,6 +245,48 @@ func TestEnsurePrefix(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tt.want, EnsurePrefix(tt.give, tt.givePrefix))
+		})
+	}
+}
+
+func TestAddPrefixList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		giveList   []string
+		givePrefix string
+		want       []string
+	}{
+		{
+			giveList:   []string{"a"},
+			givePrefix: "b",
+			want:       []string{"b/a"},
+		},
+		{
+			giveList:   []string{"/c/d/e/"},
+			givePrefix: "/f/",
+			want:       []string{"f/c/d/e/"},
+		},
+		{
+			giveList:   []string{"/g/"},
+			givePrefix: "h",
+			want:       []string{"h/g/"},
+		},
+		{
+			giveList:   []string{"i/j"},
+			givePrefix: "i",
+			want:       []string{"i/i/j"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.givePrefix, func(t *testing.T) {
+			t.Parallel()
+
+			AddPrefixList(tt.giveList, tt.givePrefix)
+
+			assert.Equal(t, tt.want, tt.giveList)
 		})
 	}
 }

--- a/api/version.go
+++ b/api/version.go
@@ -2,5 +2,5 @@ package vaku
 
 // Version gives the current Vaku API version.
 func Version() string {
-	return "2.2.0"
+	return "2.3.0"
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestVersion(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t, "2.2.0", Version())
+	assert.Equal(t, "2.3.0", Version())
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -19,12 +19,12 @@ func TestVersion(t *testing.T) {
 		{
 			name:        "version test",
 			giveVersion: "test",
-			wantOut:     "API: 2.2.0\nCLI: test\n",
+			wantOut:     "API: 2.3.0\nCLI: test\n",
 		},
 		{
 			name:        "version version",
 			giveVersion: "version",
-			wantOut:     "API: 2.2.0\nCLI: version\n",
+			wantOut:     "API: 2.3.0\nCLI: version\n",
 		},
 		{
 			name:        "args",


### PR DESCRIPTION
I finally managed to reproduce the issue, and it seemed to be an easy fix for the search part at least.

- Run Vault locally: `docker run -p "8200:8200" -e VAULT_DEV_ROOT_TOKEN_ID=my-login-token vault:1.7.1`
- Once you run the command above, you'll have Vault running on `http://localhost:8200`.
- Go to the UI, login with the token `my-login-token`. 
- Once you are in, create a KV mount named `test`.
- In this mount, create a secret with the path `test/some-secret`, put `key` as the `key` and `value` as the value.
- The final path should look like this:

![image](https://user-images.githubusercontent.com/16530606/118301282-2c600c00-b4e3-11eb-860e-ace63464eb55.png)

At this point, run the master branch against your local Vault instance with a single worker:
```
❯ go build && ./vaku folder search test value --address="http://localhost:8200" --token="my-login-token" --workers=1
```

This will never end because Vaku is falling into an infinite loop.

Now checkout to this PR, and run it with the same command, it'll work:
```
❯ go build && ./vaku folder search test value --address="http://localhost:8200" --token="myroot" --workers=1
test/some-secret
```

I haven't used the other commands in Vaku, I mainly needed the search functionality and this PR seems to fix it. 
