### PR TITLE
Bugfix: Worker threading issues resulting in hung scenarios

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters-settings:
   errcheck:
     check-blank: true
   gocognit:
-    min-complexity: 10
+    min-complexity: 15
   gocyclo:
     min-complexity: 10
   nakedret:

--- a/api/folder_delete.go
+++ b/api/folder_delete.go
@@ -75,7 +75,6 @@ func (c *Client) folderDeleteWork(i *folderDeleteWorkInput) error {
 			if err != nil {
 				return err
 			}
-			return nil
 		}
 	}
 }

--- a/api/folder_destroy.go
+++ b/api/folder_destroy.go
@@ -62,7 +62,10 @@ func (c *Client) folderDestroyWork(i *folderDestroyWorkInput) error {
 				return nil
 			}
 			path = c.inputPath(path, i.root)
-			return c.PathDestroy(path, i.versions)
+			err := c.PathDestroy(path, i.versions)
+			if err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/api/folder_write.go
+++ b/api/folder_write.go
@@ -62,8 +62,10 @@ func (c *Client) folderWriteWork(i *folderWriteWorkInput) error {
 			if !ok {
 				return nil
 			}
-
-			return c.PathWrite(path, i.data[path])
+			err := c.PathWrite(path, i.data[path])
+			if err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -116,7 +116,9 @@ func initSharedVaku(t *testing.T) {
 		WithVaultSrcClient(srcClient),
 		WithVaultDstClient(dstClient),
 		WithAbsolutePath(false),
-		WithWorkers(100),
+
+		// set worker < max folder operations to expose any worker threading issue
+		WithWorkers(5),
 	)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR fixes 2 categories of issues relating to the worker threading logic which results in a hung scenario when the number of workers is less than the number of folder operations to be performed, and lowers the worker count used in tests which masked the issues. 

### Fix premature return of worker thread after processing a single operation

Worker threads are expected to handle more than one operation and should only return when either the input channel is closed (indicating there are no more operations to process) or its errgroup context is cancelled (to terminate all workers once one returns an error).

### Fix incomplete/absent errgroup context cancellation handling in folder list worker functions

The Goroutine forked from the pathListWork worker function to write into the pathC channel is missing errgroup context cancellation handling to abort waiting and decrement the waitgroup counter, which blocks the pathC, resC and errC channels from being closed/returned resulting in a hung scenario.

The folderListWork worker function also has incomplete errgroup context cancellation handling which does not return immediately if the thread is waiting to read from the pathC channel and it has not been closed. Though granted pathC would be closed with the fix to pathListWork, this changes the logic to match similar functions in other folder worker functions.