### PR TITLE
Add possibility to plug in custom mounts provider

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -58,6 +58,9 @@ func TestNewClient(t *testing.T) {
 				WithVaultSrcClient(newDefaultVaultClient(t)),
 				WithVaultDstClient(newDefaultVaultClient(t)),
 				WithAbsolutePath(true),
+				WithMountProvider(&defaultMountProvider{
+					client: &Client{},
+				}),
 			},
 			want: &Client{
 				vc: newDefaultVaultClient(t),
@@ -325,12 +328,16 @@ func assertClientsEqual(t *testing.T, expected *Client, actual *Client) {
 	// zero out clients and assert equal
 	expected.vc = nil
 	expected.vl = nil
+	expected.mountProvider = nil
 	expected.dc.vc = nil
 	expected.dc.vl = nil
+	expected.dc.mountProvider = nil
 	actual.vc = nil
 	actual.vl = nil
+	actual.mountProvider = nil
 	actual.dc.vc = nil
 	actual.dc.vl = nil
+	actual.dc.mountProvider = nil
 
 	if expected.dc.dc != expected {
 		expected.dc.dc = expected

--- a/api/mount_provider.go
+++ b/api/mount_provider.go
@@ -1,19 +1,24 @@
 package vaku
 
+// Mount is a high level representation of selected fields of a
+// vault mount that are relevant to vaku.
 type Mount struct {
 	Path    string
 	Type    string
 	Version string
 }
 
+// mountProvider is used to get a list of all mounts that the user has access to.
 type mountProvider interface {
 	ListMounts() ([]Mount, error)
 }
 
+// defaultMountProvider is used if no other mountProvider is supplied.
 type defaultMountProvider struct {
 	client *Client
 }
 
+// ListMounts lists mounts using the sys/mounts endpoint.
 func (p defaultMountProvider) ListMounts() ([]Mount, error) {
 	mounts, err := p.client.vc.Sys().ListMounts()
 	if err != nil {
@@ -22,7 +27,6 @@ func (p defaultMountProvider) ListMounts() ([]Mount, error) {
 
 	result := make([]Mount, 0)
 	for mountPath, data := range mounts {
-		// Ensure '/' so that no match on foo/bar/ when actual path is foo/barbar/
 		mount := Mount{
 			Path:    mountPath,
 			Type:    data.Type,

--- a/api/mount_provider.go
+++ b/api/mount_provider.go
@@ -1,0 +1,34 @@
+package vaku
+
+type Mount struct {
+	Path    string
+	Type    string
+	Version string
+}
+
+type mountProvider interface {
+	ListMounts() ([]Mount, error)
+}
+
+type defaultMountProvider struct {
+	client *Client
+}
+
+func (p defaultMountProvider) ListMounts() ([]Mount, error) {
+	mounts, err := p.client.vc.Sys().ListMounts()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Mount, 0)
+	for mountPath, data := range mounts {
+		// Ensure '/' so that no match on foo/bar/ when actual path is foo/barbar/
+		mount := Mount{
+			Path:    mountPath,
+			Type:    data.Type,
+			Version: data.Options["version"],
+		}
+		result = append(result, mount)
+	}
+	return result, nil
+}

--- a/api/mount_provider.go
+++ b/api/mount_provider.go
@@ -22,7 +22,7 @@ type defaultMountProvider struct {
 func (p defaultMountProvider) ListMounts() ([]Mount, error) {
 	mounts, err := p.client.vc.Sys().ListMounts()
 	if err != nil {
-		return nil, err
+		return nil, newWrapErr("", ErrMountInfo, newWrapErr(err.Error(), ErrListMounts, nil))
 	}
 
 	result := make([]Mount, 0)

--- a/api/mounts.go
+++ b/api/mounts.go
@@ -43,21 +43,20 @@ const (
 
 // mountInfo takes a path and returns the mount path and version.
 func (c *Client) mountInfo(p string) (string, mountVersion, error) {
-	mounts, err := c.vc.Sys().ListMounts()
+	mounts, err := c.mountProvider.ListMounts()
 	if err != nil {
 		return "", mv0, newWrapErr(p, ErrMountInfo, newWrapErr(err.Error(), ErrListMounts, nil))
 	}
 
-	for mount, data := range mounts {
+	for _, mount := range mounts {
 		// Ensure '/' so that no match on foo/bar/ when actual path is foo/barbar/
-		mount = EnsureFolder(mount)
-		if strings.HasPrefix(p, mount) {
-			version, ok := data.Options["version"]
-			if !ok {
-				return mount, mv0, nil
+		mount.Path = EnsureFolder(mount.Path)
+		if strings.HasPrefix(p, mount.Path) {
+			if mount.Version == "" {
+				return mount.Path, mv0, nil
 			}
 
-			return mount, mountStringToVersion(version), nil
+			return mount.Path, mountStringToVersion(mount.Version), nil
 		}
 	}
 


### PR DESCRIPTION
Hi!

This relates to #157 which I've revisited now. Ultimately selecting a global version for the KV engine was not flexible enough as it would not allow for secret engines to be mounted in arbitrary locations in the tree.

This PR makes it possible to supply your own mount list through a new interface. It solves the use case I have, which is purely to use vaku as a library. I have not done any changes to the CLI (I'm not sure there are any reasonable changes to be done).

Any feedback is appreciated!